### PR TITLE
Fix 'a yee' detection

### DIFF
--- a/src/util/Logic.ts
+++ b/src/util/Logic.ts
@@ -9,7 +9,7 @@ export default class Logic {
       this.contains_amos_yee_beside(comment.body) ||
       this.contains_amos_and_yee_exact(comment.body) ||
       this.contains_polocle(comment.body) ||
-      this.contains_amos_a_y_yee(comment.body)
+      this.contains__a_yee__amos_y__y_amos(comment.body)
     ) {
       Log.info('is_amos_yee_comment', comment.id)
       return true
@@ -24,7 +24,7 @@ export default class Logic {
       thread.title.toLowerCase().includes('amos') ||
       thread.title.toLowerCase().includes('polocle') ||
       this.contains_polocle(thread.body) ||
-      this.contains_amos_a_y_yee(thread.body)
+      this.contains__a_yee__amos_y__y_amos(thread.body)
     ) {
       Log.info('is_amos_yee_thread', thread.id)
       return true
@@ -41,13 +41,12 @@ export default class Logic {
     return /\bamos\b/g.test(text.toLowerCase()) && /\byee\b/g.test(text.toLowerCase())
   }
 
-  static contains_amos_a_y_yee(text: string): boolean {
+  static contains__a_yee__amos_y__y_amos(text: string): boolean {
     const lowerText = text.toLowerCase()
-    const yee = /(\b|_)yee(\b|_)/g.test(lowerText)
-    const amos = /(\b|_)amos(\b|_)/g.test(lowerText)
-    const y = /(\b|_)y(\b|_)/g.test(lowerText)
-    const a = /(\b|_)A(\b|_)/g.test(text)
-    if ((amos && y) || (a && yee)) {
+    const a_yee = /(\b|_)a(\b|_)[^a-zA-Z0-9]*yee/g.test(lowerText)
+    const amos_y = /amos[^a-zA-Z0-9]*y/g.test(lowerText)
+    const y_amos = /(\b|_)y(\b|_)[^a-zA-Z0-9]*amos/g.test(lowerText)
+    if (a_yee || amos_y || y_amos) {
       return true
     }
     return false

--- a/tests/Logic.test.ts
+++ b/tests/Logic.test.ts
@@ -3,7 +3,7 @@ import { DateUtil } from '@aelesia/commons/dist/src/collections/util/DateUtil'
 import { Cfg } from '../src/app/config/Cfg'
 import { Time } from '@aelesia/commons'
 import { PostFactory } from './factories/Factories'
-import { Post } from '../src/db/model/Post'
+import { Post } from 'reddit-ts/src/types/models/Post.type'
 
 describe('Logic', () => {
   test('Title contains "Amos"', async () => {
@@ -214,20 +214,30 @@ describe('Logic', () => {
     ).toEqual(true)
   })
 
-  test('contains_amos_a_y_yee', () => {
-    expect(Logic.contains_amos_a_y_yee("You'll never be as useless and unsuccessful as a certain A.YEE")).toBeTruthy()
-    expect(Logic.contains_amos_a_y_yee('y_amos = y_amos += x_amos')).toBeTruthy()
+  test('contains__a_yee__amos_y__y_amos', () => {
     expect(
-      Logic.contains_amos_a_y_yee(
+      Logic.contains__a_yee__amos_y__y_amos("You'll never be as useless and unsuccessful as a certain A.YEE")
+    ).toBeTruthy()
+    expect(Logic.contains__a_yee__amos_y__y_amos('y_amos = y_amos += x_amos')).toBeTruthy()
+    expect(
+      Logic.contains__a_yee__amos_y__y_amos(
         'Is this what Amos Y- (ok I can hear the bot making angry noises) would have become if he had been given an elite education?'
       )
     ).toBeTruthy()
+
+    expect(Logic.contains__a_yee__amos_y__y_amos('a_yee')).toBeTruthy()
+    expect(Logic.contains__a_yee__amos_y__y_amos('a yee')).toBeTruthy()
+    expect(Logic.contains__a_yee__amos_y__y_amos('amos.y')).toBeTruthy()
+    expect(Logic.contains__a_yee__amos_y__y_amos('amos y')).toBeTruthy()
+
+    expect(Logic.contains__a_yee__amos_y__y_amos('A fun yee')).toBeFalsy()
+    expect(Logic.contains__a_yee__amos_y__y_amos('ayee')).toBeFalsy()
   })
 
   test('is not amos_yee thread', () => {
-    expect(Logic.contains_amos_a_y_yee('AY')).toBeFalsy()
-    expect(Logic.contains_amos_a_y_yee('A.Y')).toBeFalsy()
-    expect(Logic.contains_amos_a_y_yee('A*** Y**')).toBeFalsy()
+    expect(Logic.contains__a_yee__amos_y__y_amos('AY')).toBeFalsy()
+    expect(Logic.contains__a_yee__amos_y__y_amos('A.Y')).toBeFalsy()
+    expect(Logic.contains__a_yee__amos_y__y_amos('A*** Y**')).toBeFalsy()
     expect(
       Logic.is_amos_yee_comment({
         body:
@@ -235,5 +245,14 @@ describe('Logic', () => {
           "A Reddit post over Shaun Ho's case can be found here: NTU undergraduate admits to taking illicit videos of 335 women, including victims on campus\n"
       } as Post)
     ).toBeFalsy()
+    // https://www.reddit.com/r/singapore/comments/oubigz/zb_schools_1000_covid19_isolation_beds_in_local/h7199re/?context=3
+    expect(
+      Logic.is_amos_yee_comment({
+        body:
+          'Health Minister Ong Yee Kung revealed that the local hospital currently has 1,000 isolation beds for coronary disease patients, and the number of beds in the intensive care unit has increased to nearly 70 in the past two weeks.\n' +
+          '\n' +
+          '"The Jurong Fishing Port infected groups have turned multiple markets into infected groups and must be closed. It is also likely to spread widely in the community, especially affecting the elderly who often visit the market. A quarter of the elderly have always been If they have not been vaccinated yet, they will be at risk of serious illness if they are infected."\n'
+      } as any)
+    ).toEqual(false)
   })
 })


### PR DESCRIPTION
There is currently a check for 'A' and 'yee' in a post. This is to detect scenarios like:

- A.YEE
- A_yee
- A*** Yee

Previously it did not ensure that the two are side by side, therefore the following paragraph would trigger the detection due to finding both 'Yee' and 'A'. 

Health Minister Ong **Yee** Kung revealed that the local hospital currently has 1,000 isolation beds for coronary disease patients, and the number of beds in the intensive care unit has increased to nearly 70 in the past two weeks.

The Jurong Fishing Port infected groups have turned multiple markets into infected groups and must be closed. It is also likely to spread widely in the community, especially affecting the elderly who often visit the market. **A** quarter of the elderly have always been If they have not been vaccinated yet, they will be at risk of serious illness if they are infected.

This fix changes the logic to ensure that both 'A' and 'yee' must always be beside one another. Therefore the sentence _'A fun yee'_ would not trigger the bot.